### PR TITLE
sanitize aggregation steps: fix bug when there's multiple

### DIFF
--- a/internal/run.go
+++ b/internal/run.go
@@ -565,13 +565,16 @@ func parseUpdateOpts(opts interface{}) (bool, *options.UpdateOptions) {
 // remove any stages that might write to another db/collection,
 // to avoid leaking databases, or or other playground contamination
 func sanitize(stages []interface{}) []interface{} {
-	for i := range stages {
+
+	for i := 0; i <  len(stages); i++ {
 		stage,_ := stages[i].(map[string]interface{})
 		if _, ok := stage["$out"]; ok {
 			stages = append(stages[:i], stages[i+1:]...)
+			i--
 		}
 		if _, ok := stage["$merge"]; ok {
 			stages = append(stages[:i], stages[i+1:]...)
+			i--
 		}
 	}
 	return stages

--- a/internal/run_test.go
+++ b/internal/run_test.go
@@ -775,6 +775,26 @@ func TestRunCreateDB(t *testing.T) {
 			result:    `query failed: (TypeMismatch) Each element of the 'pipeline' array must be an object`,
 			createdDB: 1,
 		},
+		{
+			name: `aggregation with $merge in first pos`,
+			params: url.Values{
+				"mode":   {"bson"},
+				"config": {`[{"_id":1}]`},
+				"query":  {`db.collection.aggregate([{$merge: "ouptut-merge"},{$match:{_id:1}},{$project:{_id:0}}])`},
+			},
+			result:    `[{}]`,
+			createdDB: 1,
+		},
+		{
+			name: `aggregation with $out and $merge`,
+			params: url.Values{
+				"mode":   {"bson"},
+				"config": {`[{"_id":1},{"_id":2},{"_id":3},{"_id":38294834}]`},
+				"query":  {`db.collection.aggregate([{$merge: "ouptut-merge"},{"$match":{"_id":1}},{"$out": {db: "ouptut", collection: "y"}}])`},
+			},
+			result:    `[{"_id":1}]`,
+			createdDB: 1,
+		},
 	}
 
 	t.Run("parallel run", func(t *testing.T) {


### PR DESCRIPTION
steps, and $out/$merge is not the last step