### PR TITLE
Correct aggregationSnippet "$getField" and "$setField" "fields"->"field"

### DIFF
--- a/internal/web/snippets.js
+++ b/internal/web/snippets.js
@@ -1103,12 +1103,12 @@ var aggregationSnippet = [
     },
     {
         caption: "$getField",
-        value: '$getField: { "fields": "string", "input": "object" }',
+        value: '$getField: { "field": "string", "input": "object" }',
         meta: "aggregation operator"
     },
     {
         caption: "$setField",
-        value: '$setField: { "fields": "string", "input": "object", "value": "expression" }',
+        value: '$setField: { "field": "string", "input": "object", "value": "expression" }',
         meta: "aggregation operator"
     },
     {


### PR DESCRIPTION
Only deleted two characters, changing `"fields"` to `"field"`, in `aggregationSnippet`'s `"$getField"` and `"$setField"`.  This matches the correct syntax.