### PR TITLE
Fixed internal links and added more for navigation

### DIFF
--- a/internal/web/static/docs.html
+++ b/internal/web/static/docs.html
@@ -89,35 +89,36 @@
   <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span>     <span class="pl-c">// optional, int between 0 and 100. Percentage of documents</span>
                                 <span class="pl-c">// that will have this field</span>
 <span class="pl-kos">}</span></pre></div>
+<a id="mgodatagen-list-top"/>
     <p>List of basic <code>&lt;generator&gt;</code> types:</p>
     <ul>
-        <li><a href="#string">string</a></li>
-        <li><a href="#int">int</a></li>
-        <li><a href="#long">long</a></li>
-        <li><a href="#double">double</a></li>
-        <li><a href="#decimal">decimal</a></li>
-        <li><a href="#autoincrement">autoincrement</a></li>
-        <li><a href="#boolean">boolean</a></li>
-        <li><a href="#objectid">objectId</a></li>
-        <li><a href="#binary">binary</a></li>
-        <li><a href="#date">date</a></li>
-        <li><a href="#uuid">UUID</a></li>
-        <li><a href="#position">position</a></li>
-        <li><a href="#faker">faker</a></li>
+        <li><a href="#mgodatagen-string">string</a></li>
+        <li><a href="#mgodatagen-int">int</a></li>
+        <li><a href="#mgodatagen-long">long</a></li>
+        <li><a href="#mgodatagen-double">double</a></li>
+        <li><a href="#mgodatagen-decimal">decimal</a></li>
+        <li><a href="#mgodatagen-autoincrement">autoincrement</a></li>
+        <li><a href="#mgodatagen-boolean">boolean</a></li>
+        <li><a href="#mgodatagen-objectid">objectId</a></li>
+        <li><a href="#mgodatagen-binary">binary</a></li>
+        <li><a href="#mgodatagen-date">date</a></li>
+        <li><a href="#mgodatagen-uuid">UUID</a></li>
+        <li><a href="#mgodatagen-position">position</a></li>
+        <li><a href="#mgodatagen-faker">faker</a></li>
     </ul>
     <p>List of composite <code>&lt;generator&gt;</code> types:</p>
     <ul>
-        <li><a href="#array">array</a></li>
-        <li><a href="#object">object</a></li>
-        <li><a href="#constant">constant</a></li>
-        <li><a href="#ref">reference</a></li>
-        <li><a href="#fromarray">fromArray</a></li>
-        <li><a href="#stringFromParts">stringFromParts</a></li>
-        <li><a href="#countAggregator">countAggregator</a></li>
-        <li><a href="#valueAggregator">valueAggregator</a></li>
-        <li><a href="#boundAggregator">boundAggregator</a></li>
+        <li><a href="#mgodatagen-array">array</a></li>
+        <li><a href="#mgodatagen-object">object</a></li>
+        <li><a href="#mgodatagen-constant">constant</a></li>
+        <li><a href="#mgodatagen-ref">reference</a></li>
+        <li><a href="#mgodatagen-fromarray">fromArray</a></li>
+        <li><a href="#mgodatagen-stringFromParts">stringFromParts</a></li>
+        <li><a href="#mgodatagen-countAggregator">countAggregator</a></li>
+        <li><a href="#mgodatagen-valueAggregator">valueAggregator</a></li>
+        <li><a href="#mgodatagen-boundAggregator">boundAggregator</a></li>
     </ul>
-    <h3><a id="user-content-string" class="anchor" aria-hidden="true" href="#string"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>String</h3>
+    <h3><a id="mgodatagen-string" class="anchor" aria-hidden="true" href="#string"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>String</h3>
     <p>Generates a random string of a certain length. String is composed of char within this list:
         <code>abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_</code></p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
@@ -128,7 +129,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>    <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>     <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h4><a id="user-content-unique-string" class="anchor" aria-hidden="true" href="#unique-string"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Unique String</h4>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-unique-string" class="anchor" aria-hidden="true" href="#unique-string"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Unique String</h3>
     <p>If <code>unique</code> is set to true, the field will only contains unique strings. Unique strings
         have a <strong>fixed length</strong>, <code>minLength</code> is taken as length for the string.
         There is <code>64^x</code> possible unique string for strings of length <code>x</code>. This number has to
@@ -142,7 +144,8 @@
 "aad",
 ...
 </code></pre>
-    <h3><a id="user-content-int" class="anchor" aria-hidden="true" href="#int"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Int</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-int" class="anchor" aria-hidden="true" href="#int"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Int</h3>
     <p>Generates a random <code>int</code> within bounds.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"int"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -151,7 +154,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span> <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>  <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-long" class="anchor" aria-hidden="true" href="#long"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Long</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-long" class="anchor" aria-hidden="true" href="#long"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Long</h3>
     <p>Generates a random <code>long</code> within bounds.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"long"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -160,7 +164,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>  <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>   <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-double" class="anchor" aria-hidden="true" href="#double"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Double</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-double" class="anchor" aria-hidden="true" href="#double"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Double</h3>
     <p>Generates a random <code>double</code> within bounds.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"double"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -169,28 +174,32 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>    <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>     <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-decimal" class="anchor" aria-hidden="true" href="#decimal"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Decimal</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-decimal" class="anchor" aria-hidden="true" href="#decimal"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Decimal</h3>
     <p>Generates a random <code>decimal128</code>.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"decimal"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>     <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span><span class="pl-kos">,</span>     <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-boolean" class="anchor" aria-hidden="true" href="#boolean"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Boolean</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-boolean" class="anchor" aria-hidden="true" href="#boolean"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Boolean</h3>
     <p>Generates a random <code>boolean</code>.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"boolean"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>     <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>      <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-objectid" class="anchor" aria-hidden="true" href="#objectid"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>ObjectId</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-objectid" class="anchor" aria-hidden="true" href="#objectid"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>ObjectId</h3>
     <p>Generates a random <code>objectId</code>.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"objectId"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>      <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>       <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-array" class="anchor" aria-hidden="true" href="#array"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Array</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-array" class="anchor" aria-hidden="true" href="#array"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Array</h3>
     <p>Generates a random array of bson object.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"array"</span><span class="pl-kos">,</span>     <span class="pl-c">// required</span>
@@ -200,7 +209,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>        <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-object" class="anchor" aria-hidden="true" href="#object"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Object</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-object" class="anchor" aria-hidden="true" href="#object"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Object</h3>
     <p>Generates random nested object.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:                <span class="pl-s">"object"</span><span class="pl-kos">,</span>    <span class="pl-c">// required</span>
@@ -212,7 +222,8 @@
     <span class="pl-s">"nullPercentage"</span>:      <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>:    <span class="pl-s">`int`</span>        <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-binary" class="anchor" aria-hidden="true" href="#binary"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Binary</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-binary" class="anchor" aria-hidden="true" href="#binary"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Binary</h3>
     <p>Generates random binary data of length within bounds.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"binary"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -221,7 +232,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>    <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>     <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-date" class="anchor" aria-hidden="true" href="#date"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Date</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-date" class="anchor" aria-hidden="true" href="#date"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Date</h3>
     <p>Generates a random date (stored as <a href="https://docs.mongodb.com/manual/reference/method/Date/" rel="nofollow"><code>ISODate</code></a> ).</p>
     <p><code>startDate</code> and <code>endDate</code> are string representation of a Date following RFC3339:</p>
     <p><strong>format</strong>: "yyyy-MM-ddThh:mm:ss+00:00"</p>
@@ -232,7 +244,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>    <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>     <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-position" class="anchor" aria-hidden="true" href="#position"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Position</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-position" class="anchor" aria-hidden="true" href="#position"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Position</h3>
     <p>Generates a random GPS position in Decimal Degrees ( WGS 84),
         eg : [40.741895, -73.989308]</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
@@ -240,7 +253,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>      <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>       <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-constant" class="anchor" aria-hidden="true" href="#constant"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Constant</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-constant" class="anchor" aria-hidden="true" href="#constant"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Constant</h3>
     <p>Add the same value to each document.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:           <span class="pl-s">"constant"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -248,7 +262,8 @@
                                   <span class="pl-c">// eg: {"k": 1, "v": "val"}</span>
     <span class="pl-s">"nullPercentage"</span>: <span class="pl-s">`int`</span>       <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-autoincrement" class="anchor" aria-hidden="true" href="#autoincrement"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Autoincrement</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-autoincrement" class="anchor" aria-hidden="true" href="#autoincrement"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Autoincrement</h3>
     <p>Generates an autoincremented value (type <code>&lt;long&gt;</code> or <code>&lt;int&gt;</code>).</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:           <span class="pl-s">"autoincrement"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -257,7 +272,8 @@
     <span class="pl-s">"startInt"</span>:       <span class="pl-s">`int`</span><span class="pl-kos">,</span>           <span class="pl-c">// optional, start value if autoType = int</span>
     <span class="pl-s">"nullPercentage"</span>: <span class="pl-s">`int`</span>            <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-ref" class="anchor" aria-hidden="true" href="#ref"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Ref</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-ref" class="anchor" aria-hidden="true" href="#ref"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Ref</h3>
     <p>If a field reference an other field in a different collection, you can use a ref generator.</p>
     <p>generator in first collection:</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>:<span class="pl-kos">{</span>
@@ -275,7 +291,8 @@
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span> <span class="pl-c">// optional</span>
     <span class="pl-s">"maxDistinctValue"</span>: <span class="pl-s">`int`</span>  <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-fromarray" class="anchor" aria-hidden="true" href="#fromarray"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>FromArray</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-fromarray" class="anchor" aria-hidden="true" href="#fromarray"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>FromArray</h3>
     <p>Pick an object from an array as value for the field. Currently, objects in the
         array have to be of the same type. By default, items are picked from the array
         in the order where they appear.</p>
@@ -291,13 +308,15 @@
     <span class="pl-s">"nullPercentage"</span>: <span class="pl-s">`int`</span>   <span class="pl-c">// optional</span>
 
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-uuid" class="anchor" aria-hidden="true" href="#uuid"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>UUID</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-uuid" class="anchor" aria-hidden="true" href="#uuid"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>UUID</h3>
     <p>Generate a random UUID ( using <a href="https://godoc.org/github.com/satori/go.uuid#NewV4" rel="nofollow">satori/go.uuid NewV4()</a>).</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:           <span class="pl-s">"uuid"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
     <span class="pl-s">"nullPercentage"</span>: <span class="pl-s">`int`</span>   <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-stringfromparts" class="anchor" aria-hidden="true" href="#stringfromparts"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>StringFromParts</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-stringFromParts" class="anchor" aria-hidden="true" href="#stringfromparts"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>StringFromParts</h3>
     <p>Generate a random string from several generators</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:           <span class="pl-s">"stringFromParts"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
@@ -334,7 +353,8 @@
     <span class="pl-kos">}</span><span class="pl-kos">,</span>
   <span class="pl-kos">]</span>
 <span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-countaggregator" class="anchor" aria-hidden="true" href="#countaggregator"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>CountAggregator</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-countAggregator" class="anchor" aria-hidden="true" href="#countaggregator"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>CountAggregator</h3>
     <p>Count documents from <code>&lt;database&gt;.&lt;collection&gt;</code> matching a specific query. To use a
         variable of the document in the query, prefix it with "$$".</p>
     <p>The query can't be empty or null.</p>
@@ -374,7 +394,8 @@
     <p>The collection <code>second</code> will contain:</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-kos">{</span><span class="pl-s">"_id"</span>: <span class="pl-c1">1</span><span class="pl-kos">,</span> <span class="pl-s">"count"</span>: <span class="pl-c1">2</span><span class="pl-kos">}</span>
 <span class="pl-kos">{</span><span class="pl-s">"_id"</span>: <span class="pl-c1">2</span><span class="pl-kos">,</span> <span class="pl-s">"count"</span>: <span class="pl-c1">1</span><span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-valueaggregator" class="anchor" aria-hidden="true" href="#valueaggregator"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>ValueAggregator</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-valueAggregator" class="anchor" aria-hidden="true" href="#valueaggregator"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>ValueAggregator</h3>
     <p>Get distinct values for a specific field for documents from
         <code>&lt;database&gt;.&lt;collection&gt;</code> matching a specific query. To use a variable of
         the document in the query, prefix it with "$$".</p>
@@ -417,7 +438,8 @@
     <p>The collection <code>second</code> will contain:</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-kos">{</span><span class="pl-s">"_id"</span>: <span class="pl-c1">1</span><span class="pl-kos">,</span> <span class="pl-s">"values"</span>: <span class="pl-kos">[</span><span class="pl-s">"a"</span><span class="pl-kos">,</span> <span class="pl-s">"b"</span><span class="pl-kos">]</span><span class="pl-kos">}</span>
 <span class="pl-kos">{</span><span class="pl-s">"_id"</span>: <span class="pl-c1">2</span><span class="pl-kos">,</span> <span class="pl-s">"values"</span>: <span class="pl-kos">[</span><span class="pl-s">"c"</span><span class="pl-kos">]</span><span class="pl-kos">}</span></pre></div>
-    <h3><a id="user-content-boundaggregator" class="anchor" aria-hidden="true" href="#boundaggregator"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>BoundAggregator</h3>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-boundAggregator" class="anchor" aria-hidden="true" href="#boundaggregator"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>BoundAggregator</h3>
     <p>Get the lowest and highest value for a specific field of documents in
         <code>&lt;database&gt;.&lt;collection&gt;</code> matching a specific query. To use a variable of
         the document in the query, prefix it with "$$"</p>
@@ -464,7 +486,8 @@
     <div class="highlight highlight-source-js"><pre><span class="pl-kos">{</span><span class="pl-s">"_id"</span>: <span class="pl-c1">1</span><span class="pl-kos">,</span> <span class="pl-s">"values"</span>: <span class="pl-kos">{</span><span class="pl-s">"m"</span>: <span class="pl-c1">0</span><span class="pl-kos">,</span> <span class="pl-s">"M"</span>: <span class="pl-c1">10</span><span class="pl-kos">}</span><span class="pl-kos">}</span>
 <span class="pl-kos">{</span><span class="pl-s">"_id"</span>: <span class="pl-c1">2</span><span class="pl-kos">,</span> <span class="pl-s">"values"</span>: <span class="pl-kos">{</span><span class="pl-s">"m"</span>: <span class="pl-c1">15</span><span class="pl-kos">,</span> <span class="pl-s">"M"</span>: <span class="pl-c1">200</span><span class="pl-kos">}</span><span class="pl-kos">}</span></pre></div>
     <p>where <code>m</code> is the min value, and <code>M</code> the max value.</p>
-    <h3><a id="user-content-faker" class="anchor" aria-hidden="true" href="#faker"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Faker</h3>
+    <div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
+    <h3><a id="mgodatagen-faker" class="anchor" aria-hidden="true" href="#faker"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Faker</h3>
     <p>Generate 'real' data using <a href="https://github.com/brianvoe/gofakeit">gofakeit library</a>.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"faker"</span><span class="pl-kos">,</span>  <span class="pl-c">// required</span>
@@ -580,6 +603,7 @@
 "BeerStyle"
 "BeerYeast"
 </code></pre>
+<div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
   <h1>
   <a id="user-content-limitations" class="anchor" href="#limitations" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Limitations</h1>
   <h3>
@@ -607,4 +631,5 @@
       <span class="pl-s"><span class="pl-pds">"</span>$regex<span class="pl-pds">"</span></span><span class="pl-k">:</span> <span class="pl-s"><span class="pl-pds">"</span>pattern<span class="pl-pds">"</span></span>
     }
   })</pre></div>
+  <div style="text-align: right;font-size: small"><a href="#top">^Back to the top</a></div>
 </div>

--- a/internal/web/static/docs.html
+++ b/internal/web/static/docs.html
@@ -203,7 +203,6 @@
     <p>Generates a random array of bson object.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"array"</span><span class="pl-kos">,</span>     <span class="pl-c">// required</span>
-    <span class="pl-s">"size"</span>:             <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// size of the array, DEPRECATED, use minLength and maxLength instead</span>
     <span class="pl-s">"minLength"</span>:        <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// required, must be >= 0</span>
     <span class="pl-s">"maxLength"</span>:        <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// required, must be >= minLength</span>
     <span class="pl-s">"arrayContent"</span>:     <span class="pl-s">`generator`</span><span class="pl-kos">,</span> <span class="pl-c">// generator use to create element to fill the array.</span>

--- a/internal/web/static/docs.html
+++ b/internal/web/static/docs.html
@@ -203,7 +203,9 @@
     <p>Generates a random array of bson object.</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
     <span class="pl-s">"type"</span>:             <span class="pl-s">"array"</span><span class="pl-kos">,</span>     <span class="pl-c">// required</span>
-    <span class="pl-s">"size"</span>:             <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// required, size of the array</span>
+    <span class="pl-s">"size"</span>:             <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// size of the array, DEPRECATED, use minLength and maxLength instead</span>
+    <span class="pl-s">"minLength"</span>:        <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// required, must be >= 0</span>
+    <span class="pl-s">"maxLength"</span>:        <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// required, must be >= minLength</span>
     <span class="pl-s">"arrayContent"</span>:     <span class="pl-s">`generator`</span><span class="pl-kos">,</span> <span class="pl-c">// generator use to create element to fill the array.</span>
                                      <span class="pl-c">// can be of any type</span>
     <span class="pl-s">"nullPercentage"</span>:   <span class="pl-s">`int`</span><span class="pl-kos">,</span>       <span class="pl-c">// optional</span>
@@ -312,9 +314,13 @@
     <h3><a id="mgodatagen-uuid" class="anchor" aria-hidden="true" href="#uuid"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>UUID</h3>
     <p>Generate a random UUID ( using <a href="https://godoc.org/github.com/satori/go.uuid#NewV4" rel="nofollow">satori/go.uuid NewV4()</a>).</p>
     <div class="highlight highlight-source-js"><pre><span class="pl-s">"fieldName"</span>: <span class="pl-kos">{</span>
-    <span class="pl-s">"type"</span>:           <span class="pl-s">"uuid"</span><span class="pl-kos">,</span> <span class="pl-c">// required</span>
-    <span class="pl-s">"nullPercentage"</span>: <span class="pl-s">`int`</span>   <span class="pl-c">// optional</span>
+    <span class="pl-s">"type"</span>:           <span class="pl-s">"uuid"</span><span class="pl-kos">,</span>   <span class="pl-c">// required</span>
+    <span class="pl-s">"format"</span>:         <span class="pl-s">`string`</span><span class="pl-kos">,</span> <span class="pl-c">// optional, either "string" or "binary".</span>
+                                <span class="pl-c">// default is "string"</span>
+    <span class="pl-s">"nullPercentage"</span>: <span class="pl-s">`int`</span>     <span class="pl-c">// optional</span>
 <span class="pl-kos">}</span></pre></div>
+<p>If <code>format</code> is "string", the field will be a simple string like "f1b9b567-9b34-45af-9d9c-35f565d57716".</p>
+<p>If <code>format</code> is "binary", the field will be stored as a bson UUID (see <a href="https://bsonspec.org/spec.html" rel="nofollow">bsonspec.org/spec.html</a>) like <code>BinData(4,"8bm1Z5s0Ra+dnDX1ZdV3Fg==")</code>.</p>
 <div style="text-align: right;font-size: small"><a href="#mgodatagen-list-top">^Back to the list of <code>&lt;generator&gt;</code> types</a></div>
     <h3><a id="mgodatagen-stringFromParts" class="anchor" aria-hidden="true" href="#stringfromparts"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>StringFromParts</h3>
     <p>Generate a random string from several generators</p>


### PR DESCRIPTION
Ref: #112 

I fixed the internal links for the `mgodatagen` sections.  I also added navigation links at the end of every generator type so that it's easier to get back to the list.  It should save on a lot of scrolling to get from one generator to another.

My changes need to be tested and reviewed.  I could really only view the single webpage, `docs.html`, and I don't think all the markdown was rendered accurately in my viewer.  Hopefully everything renders correctly in it's real setting.

I didn't delete all the curious `href` assignments in the anchors since they seem to be virtually everywhere and there's no real way for me to evaluate those, mostly due to my lack of HTML knowledge.  In addition, I also don't know what all the `<div>` and `class` assignments are, so I was reluctant to slice out code I didn't understand.

I think my changes will improve usability and I hope they help.

I look forward to your review.
