### PR TITLE
remove space caused by typo in auto-complete of $dateDiff

### DIFF
--- a/internal/web/src/completer.js
+++ b/internal/web/src/completer.js
@@ -1078,7 +1078,7 @@ var Completer = function (config) {
         },
         {
             caption: "$dateDiff",
-            value: '$dateDiff: {\n "startDate": "dateExpression",\n "unit": "Unit",\n" amount": "int",\n "timezone": "tzExpression",\n "startOfWeek": "day"\n}',
+            value: '$dateDiff: {\n "startDate": "dateExpression",\n "unit": "Unit",\n"amount": "int",\n "timezone": "tzExpression",\n "startOfWeek": "day"\n}',
             meta: "date operator (v5.0+)"
         },
         {


### PR DESCRIPTION
remove space caused by typo in auto-complete of `amount` clause of `$dateDiff`